### PR TITLE
Improve scroll seeking in shorter videos/music

### DIFF
--- a/src/xplayer-object.c
+++ b/src/xplayer-object.c
@@ -3726,18 +3726,13 @@ xplayer_action_handle_scroll (XplayerObject    *xplayer,
 	if (xplayer_fullscreen_is_fullscreen (xplayer->fs) != FALSE)
 		xplayer_fullscreen_show_popups (xplayer->fs, TRUE);
 
-	if (direction == GDK_SCROLL_SMOOTH) {
-		gdouble y;
-		gdk_event_get_scroll_deltas (event, NULL, &y);
-		direction = y >= 0.0 ? GDK_SCROLL_DOWN : GDK_SCROLL_UP;
-	}
 
 	switch (direction) {
 	case GDK_SCROLL_UP:
-		xplayer_action_seek_relative (xplayer, SEEK_FORWARD_SHORT_OFFSET * 1000, FALSE);
+		xplayer_action_seek_relative (xplayer, xplayer->stream_length / 500, FALSE);
 		break;
 	case GDK_SCROLL_DOWN:
-		xplayer_action_seek_relative (xplayer, SEEK_BACKWARD_SHORT_OFFSET * 1000, FALSE);
+		xplayer_action_seek_relative (xplayer, xplayer->stream_length / 500, FALSE);
 		break;
 	default:
 		retval = FALSE;

--- a/src/xplayer-object.c
+++ b/src/xplayer-object.c
@@ -3727,16 +3727,16 @@ xplayer_action_handle_scroll (XplayerObject    *xplayer,
 		xplayer_fullscreen_show_popups (xplayer->fs, TRUE);
 
 
-	switch (direction) {
-	case GDK_SCROLL_UP:
-		xplayer_action_seek_relative (xplayer, xplayer->stream_length / 500, FALSE);
-		break;
-	case GDK_SCROLL_DOWN:
-		xplayer_action_seek_relative (xplayer, xplayer->stream_length / 500, FALSE);
-		break;
-	default:
-		retval = FALSE;
-	}
+    switch (direction) {
+    case GDK_SCROLL_UP:
+        xplayer_action_seek_relative (xplayer, xplayer->stream_length / 500, FALSE);
+        break;
+    case GDK_SCROLL_DOWN:
+        xplayer_action_seek_relative (xplayer, -xplayer->stream_length / 500, FALSE);
+        break;
+    default:
+        retval = FALSE;
+    }
 
 	return retval;
 }


### PR DESCRIPTION
Before when trying to scroll seek in music or video files that were shorter in length, the seek would jump too much because the distance was based on constants, with this change it's based on the length of the file.