### PR TITLE
Explicitly use python2 in py-compile

### DIFF
--- a/py-compile
+++ b/py-compile
@@ -29,7 +29,7 @@ scriptversion=2011-06-08.12; # UTC
 # <automake-patches@gnu.org>.
 
 if [ -z "$PYTHON" ]; then
-  PYTHON=python
+  PYTHON=python2
 fi
 
 me=py-compile


### PR DESCRIPTION
Changes the default PYTHON from "python" to "python2". This patch has been in the AUR PKGBUILD for a while for compatibility with arch linux.