### PR TITLE
backend: Automatically rotate mobile phone videos

### DIFF
--- a/src/backend/bacon-video-widget.c
+++ b/src/backend/bacon-video-widget.c
@@ -1724,6 +1724,37 @@ bvw_check_missing_plugins_on_preroll (BaconVideoWidget * bvw)
 }
 
 static void
+update_orientation_from_video (BaconVideoWidget *bvw)
+{
+  BvwRotation rotation = BVW_ROTATION_R_ZERO;
+  char *orientation_str = NULL;
+  gboolean ret;
+  gdouble angle;
+
+  /* Don't change the rotation if explicitely set */
+  if (bvw->priv->rotation != BVW_ROTATION_R_ZERO)
+    return;
+
+  ret = gst_tag_list_get_string_index (bvw->priv->tagcache,
+				       GST_TAG_IMAGE_ORIENTATION, 0, &orientation_str);
+  if (!ret || !orientation_str)
+    rotation = BVW_ROTATION_R_ZERO;
+  else if (g_str_equal (orientation_str, "rotate-90"))
+    rotation = BVW_ROTATION_R_90R;
+  else if (g_str_equal (orientation_str, "rotate-180"))
+    rotation = BVW_ROTATION_R_180;
+  else if (g_str_equal (orientation_str, "rotate-270"))
+    rotation = BVW_ROTATION_R_90L;
+  else
+    g_warning ("Unhandled orientation value: '%s'", orientation_str);
+
+  g_free (orientation_str);
+
+  angle = rotation * 90.0;
+  xplayer_aspect_frame_set_rotation (XPLAYER_ASPECT_FRAME (bvw->priv->frame), angle);
+}
+
+static void
 bvw_update_tags (BaconVideoWidget * bvw, GstTagList *tag_list, const gchar *type)
 {
   GstTagList **cache = NULL;
@@ -1760,6 +1791,8 @@ bvw_update_tags (BaconVideoWidget * bvw, GstTagList *tag_list, const gchar *type
   bvw_check_for_cover_pixbuf (bvw);
 
   g_signal_emit (bvw, bvw_signals[SIGNAL_GOT_METADATA], 0);
+
+  update_orientation_from_video (bvw);
 
   set_current_actor (bvw);
 }
@@ -3762,6 +3795,7 @@ bvw_stop_play_pipeline (BaconVideoWidget * bvw)
   bvw_reconfigure_fill_timeout (bvw, 0);
   bvw->priv->movie_par_n = bvw->priv->movie_par_d = 1;
   g_clear_object (&bvw->priv->cover_pixbuf);
+  xplayer_aspect_frame_set_internal_rotation (XPLAYER_ASPECT_FRAME (bvw->priv->frame), 0.0);
   GST_DEBUG ("stopped");
 }
 

--- a/src/backend/xplayer-aspect-frame.c
+++ b/src/backend/xplayer-aspect-frame.c
@@ -437,6 +437,18 @@ xplayer_aspect_frame_set_rotation (XplayerAspectFrame *frame,
   xplayer_aspect_frame_set_rotation_internal (frame, rotation, TRUE);
 }
 
+void
+xplayer_aspect_frame_set_internal_rotation (XplayerAspectFrame *frame,
+					  gdouble           rotation)
+{
+  g_return_if_fail (XPLAYER_IS_ASPECT_FRAME (frame));
+
+  rotation = fmod (rotation, 360.0);
+
+  frame->priv->rotation = rotation;
+  xplayer_aspect_frame_set_rotation_internal (frame, rotation, FALSE);
+}
+
 gdouble
 xplayer_aspect_frame_get_rotation (XplayerAspectFrame *frame)
 {

--- a/src/backend/xplayer-aspect-frame.h
+++ b/src/backend/xplayer-aspect-frame.h
@@ -80,6 +80,9 @@ gboolean        xplayer_aspect_frame_get_expand   (XplayerAspectFrame *frame);
 
 void            xplayer_aspect_frame_set_rotation (XplayerAspectFrame *frame,
 						 gdouble           rotation);
+void            xplayer_aspect_frame_set_internal_rotation
+						(XplayerAspectFrame *frame,
+						 gdouble           rotation);
 gdouble         xplayer_aspect_frame_get_rotation (XplayerAspectFrame *frame);
 
 G_END_DECLS


### PR DESCRIPTION
based on https://git.gnome.org/browse/totem/patch/src/backend/bacon-video-widget.c?id=238a61bcf8dbf30d231b6daf445c05399944e472

From 238a61bcf8dbf30d231b6daf445c05399944e472 Mon Sep 17 00:00:00 2001
From: Bastien Nocera <hadess@hadess.net>
Date: Fri, 30 May 2014 16:23:44 +0200
Subject: backend: Automatically rotate mobile phone videos

For certain types of videos, and given a new enough version of
the "qtdemux" plugin, GStreamer will tell us which is the best
rotation for a video. This will automatically show videos the
right way around for videos captured upside-down or in portrait mode
on smartphones.


and

https://github.com/GNOME/totem/commit/a55fedc84a255d742144dabec85e58147bab0edc

From a55fedc84a255d742144dabec85e58147bab0edc Mon Sep 17 00:00:00 2001
From: Bastien Nocera <hadess@hadess.net>
Date: Fri, 30 May 2014 16:22:26 +0200
Subject: [PATCH] backend: Add a way to rotate without animations