### PR TITLE
backend: Remove use of obsolete clutter function

### DIFF
--- a/src/backend/bacon-video-widget.c
+++ b/src/backend/bacon-video-widget.c
@@ -6010,7 +6010,7 @@ bacon_video_widget_initable_init (GInitable     *initable,
 
   /* The OSD */
   bvw->priv->osd = bacon_video_osd_actor_new ();
-  clutter_actor_set_anchor_point (bvw->priv->osd, -OSD_MARGIN, -OSD_MARGIN); /* FIXME RTL */
+  clutter_actor_set_pivot_point (bvw->priv->osd, -OSD_MARGIN, -OSD_MARGIN); /* FIXME RTL */
   clutter_actor_set_size (bvw->priv->osd, OSD_SIZE, OSD_SIZE);
   clutter_actor_add_child (bvw->priv->stage, bvw->priv->osd);
   clutter_actor_set_child_above_sibling (bvw->priv->stage,


### PR DESCRIPTION
Based on https://git.gnome.org/browse/totem/patch/?id=5f274ba9511aee83267ad90ca9b9c9f3db0a84d5

From 5f274ba9511aee83267ad90ca9b9c9f3db0a84d5 Mon Sep 17 00:00:00 2001
From: Bastien Nocera <hadess@hadess.net>
Date: Wed, 6 Mar 2013 22:37:11 +0100
Subject: backend: Remove use of obsolete clutter function