### PR TITLE
backend: Don't warn when rotation is unset

### DIFF
--- a/src/backend/bacon-video-widget.c
+++ b/src/backend/bacon-video-widget.c
@@ -1737,7 +1737,7 @@ update_orientation_from_video (BaconVideoWidget *bvw)
 
   ret = gst_tag_list_get_string_index (bvw->priv->tagcache,
 				       GST_TAG_IMAGE_ORIENTATION, 0, &orientation_str);
-  if (!ret || !orientation_str)
+  if (!ret || !orientation_str || g_str_equal (orientation_str, "rotate-0"))
     rotation = BVW_ROTATION_R_ZERO;
   else if (g_str_equal (orientation_str, "rotate-90"))
     rotation = BVW_ROTATION_R_90R;


### PR DESCRIPTION
based on https://git.gnome.org/browse/totem/patch/src/backend/bacon-video-widget.c?id=e5f01e4bb35a4ad94af5396ab6fcc7129270cb9b

From e5f01e4bb35a4ad94af5396ab6fcc7129270cb9b Mon Sep 17 00:00:00 2001
From: Bastien Nocera <hadess@hadess.net>
Date: Tue, 5 May 2015 18:35:44 +0200
Subject: backend: Don't warn when rotation is unset

But the rotation tag is present. Would throw errors like:
** (totem:3246): WARNING **: Unhandled orientation value: 'rotate-0'