### PR TITLE
build: Fix detection of valac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -317,7 +317,7 @@ AC_ARG_ENABLE([vala],
 AC_MSG_RESULT([$enable_vala])
 if test "x$enable_vala" != "xno"; then
 	AM_PROG_VALAC([$VALA_REQS])
-	if test "x$VALAC" = "x"; then
+	if test "$VALAC" = "valac"; then
 		if test "x$enable_vala" = "xyes"; then
 			AC_MSG_ERROR([Vala plugin support explicitly requested, but not found])
 		fi


### PR DESCRIPTION
Based on https://git.gnome.org/browse/totem/patch/?id=bfc31c4fca16effd9dda1a191130c80bd86a2117

From bfc31c4fca16effd9dda1a191130c80bd86a2117 Mon Sep 17 00:00:00 2001
From: Bastien Nocera <hadess@hadess.net>
Date: Mon, 27 Apr 2015 13:32:58 +0200
Subject: build: Fix detection of valac
MIME-Version: 1.0
Content-Type: text/plain; charset=UTF-8
Content-Transfer-Encoding: 8bit

AM_PROG_VALAC very helpfully sets $VALAC to:
"Absolute path to the Vala compiler, or simply ‘valac’ if no suitable
compiler Vala could be found at configure runtime."

We were checking for $VALAC being empty, thus still trying to build Vala
plugins even if Vala wasn't available.