### PR TITLE
Fix warnings

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -4,21 +4,17 @@
 srcdir=`dirname $0`
 test -z "$srcdir" && srcdir=.
 
-PKG_NAME="xplayer"
 ACLOCAL_FLAGS="-I libgd $ACLOCAL_FLAGS"
 
 (test -f $srcdir/configure.ac) || {
     echo -n "**Error**: Directory "\`$srcdir\'" does not look like the"
-    echo " top-level $PKG_NAME directory"
+    echo " top-level xplayer directory"
     exit 1
 }
-
-echo "+ Setting up submodules"
-git submodule update --init --recursive
 
 which gnome-autogen.sh || {
 	echo "You need to install gnome-common from the GNOME git"
 	exit 1
 }
 
-REQUIRED_PKG_CONFIG_VERSION=0.17.1 REQUIRED_AUTOMAKE_VERSION=1.11 USE_GNOME2_MACROS=1 . gnome-autogen.sh --enable-debug "$@"
+REQUIRED_PKG_CONFIG_VERSION=0.17.1 REQUIRED_AUTOMAKE_VERSION=1.11 . gnome-autogen.sh --enable-debug "$@"


### PR DESCRIPTION
```
+ Setting up submodules
fatal: Not a git repository (or any parent up to mount point /home)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
/usr/bin/gnome-autogen.sh
***Warning*** USE_GNOME2_MACROS is deprecated, you may remove it from autogen.sh
***Warning*** PKG_NAME is deprecated, you may remove it from autogen.sh
```