### PR TITLE
Fix configure.ac warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -20,7 +20,7 @@ AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_AUX_DIR([build-aux])
 
-AM_INIT_AUTOMAKE([1.11 dist-xz tar-ustar no-dist-gzip check-news subdir-objects])
+AM_INIT_AUTOMAKE([1.11 dist-xz tar-ustar no-dist-gzip subdir-objects])
 
 # Enable silent build when available (Automake 1.11)
 m4_ifdef([AM_SILENT_RULES],[AM_SILENT_RULES([yes])])

--- a/configure.ac
+++ b/configure.ac
@@ -20,7 +20,7 @@ AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_AUX_DIR([build-aux])
 
-AM_INIT_AUTOMAKE([1.11 dist-xz tar-ustar no-dist-gzip check-news])
+AM_INIT_AUTOMAKE([1.11 dist-xz tar-ustar no-dist-gzip check-news subdir-objects])
 
 # Enable silent build when available (Automake 1.11)
 m4_ifdef([AM_SILENT_RULES],[AM_SILENT_RULES([yes])])
@@ -36,6 +36,7 @@ YELP_HELP_INIT
 
 GOBJECT_INTROSPECTION_CHECK([0.6.7])
 
+GNOME_DEBUG_CHECK
 AC_PROG_CXX
 AM_PROG_CC_C_O
 
@@ -621,7 +622,6 @@ AM_CONDITIONAL([ENABLE_VEGAS_PLUGIN],[test "$enable_vegas_plugin" = "yes"])
 
 GLIB_GSETTINGS
 
-GNOME_DEBUG_CHECK
 GNOME_COMPILE_WARNINGS([maximum])
 GNOME_CXX_WARNINGS
 GNOME_MAINTAINER_MODE_DEFINES


### PR DESCRIPTION
```
configure.ac:624: warning: AC_PROG_CC was called before AX_CHECK_ENABLE_DEBUG
/usr/share/aclocal/ax_check_enable_debug.m4:47: AX_CHECK_ENABLE_DEBUG is expanded from...
/usr/share/aclocal/gnome-common.m4:6: GNOME_DEBUG_CHECK is expanded from...
configure.ac:624: the top level
```

and

```
libgd/Makefile.am:29: warning: source file 'libgd/gd-types-catalog.c' is in a subdirectory,
libgd/Makefile.am:29: but option 'subdir-objects' is disabled
```