### PR TITLE
Add option to use dark theme variant (overriding current system theme…

### DIFF
--- a/data/org.x.player.gschema.xml.in.in
+++ b/data/org.x.player.gschema.xml.in.in
@@ -115,5 +115,9 @@
 			<_summary>Active plugins list</_summary>
 			<_description>A list of the names of the plugins which are currently active (loaded and running).</_description>
 		</key>
+		<key name="prefer-dark-theme" type="b">
+			<default>false</default>
+			<_summary>Use dark theme variant (if available).</_summary>
+		</key>
 	</schema>
 </schemalist>

--- a/data/preferences.ui
+++ b/data/preferences.ui
@@ -595,6 +595,28 @@
 		      <property name="fill">False</property>
 		    </packing>
 		  </child>
+			<child>
+				<object class="GtkAlignment" id="alignment10">
+					<property name="visible">True</property>
+					<property name="left_padding">12</property>
+					<child>
+						<object class="GtkCheckButton" id="tpw_prefer_dark_theme_checkbutton">
+							<property name="label" translatable="yes">Use dark theme variant (if available).</property>
+							<property name="visible">True</property>
+							<property name="can_focus">False</property>
+							<property name="receives_default">False</property>
+							<property name="use_action_appearance">False</property>
+							<property name="use_underline">True</property>
+							<property name="draw_indicator">True</property>
+						</object>
+					</child>
+				</object>
+				<packing>
+					<property name="expand">False</property>
+					<property name="fill">False</property>
+					<property name="position">1</property>
+				</packing>
+			</child>
 
 		  <child>
 		    <object class="GtkAlignment" id="alignment4">

--- a/src/xplayer-preferences.c
+++ b/src/xplayer-preferences.c
@@ -263,6 +263,23 @@ visualization_quality_writable_changed_cb (GSettings *settings, const gchar *key
 	gtk_widget_set_sensitive (PWID ("tpw_visuals_size_combobox"), writable && show_visualizations);
 }
 
+static void
+prefer_dark_theme_changed_cb (GSettings *settings,
+							  const gchar *key,
+							  XplayerObject *xplayer) {
+
+	GtkSettings *gtk_settings;
+	gboolean prefer_dark_theme;
+
+	g_return_if_fail (0 == strcmp (key, "prefer-dark-theme"));
+
+	prefer_dark_theme = g_settings_get_boolean (settings, "prefer-dark-theme");
+	gtk_settings = gtk_settings_get_default ();
+
+	g_object_set (G_OBJECT (gtk_settings), "gtk-application-prefer-dark-theme", prefer_dark_theme, NULL);
+
+}
+
 void
 xplayer_setup_preferences (Xplayer *xplayer)
 {
@@ -339,6 +356,11 @@ xplayer_setup_preferences (Xplayer *xplayer)
 	g_settings_bind (xplayer->settings, "disable-deinterlacing", item, "active", G_SETTINGS_BIND_DEFAULT);
 	g_settings_bind (xplayer->settings, "disable-deinterlacing", bvw, "deinterlacing",
 	                 G_SETTINGS_BIND_DEFAULT | G_SETTINGS_BIND_NO_SENSITIVITY | G_SETTINGS_BIND_INVERT_BOOLEAN);
+
+	/* Prefer dark theme */
+	item = POBJ ("tpw_prefer_dark_theme_checkbutton");
+	g_settings_bind (xplayer->settings, "prefer-dark-theme", item, "active", G_SETTINGS_BIND_DEFAULT);
+	g_signal_connect(xplayer->settings, "changed::prefer-dark-theme", (GCallback) prefer_dark_theme_changed_cb, xplayer);
 
 	/* Enable visuals */
 	item = POBJ ("tpw_visuals_checkbutton");

--- a/src/xplayer.c
+++ b/src/xplayer.c
@@ -91,8 +91,10 @@ app_init (Xplayer *xplayer, char **argv)
 	if (gtk_clutter_init (NULL, NULL) != CLUTTER_INIT_SUCCESS)
 		g_warning ("gtk-clutter failed to initialise, expect problems from here on.");
 
-	gtk_settings = gtk_settings_get_default ();
-	g_object_set (G_OBJECT (gtk_settings), "gtk-application-prefer-dark-theme", TRUE, NULL);
+	if (TRUE == g_settings_get_boolean (xplayer->settings, "prefer-dark-theme")) {
+		gtk_settings = gtk_settings_get_default ();
+		g_object_set (G_OBJECT (gtk_settings), "gtk-application-prefer-dark-theme", TRUE, NULL);
+	}
 
 	/* Debug log handling */
 	g_log_set_handler (G_LOG_DOMAIN, G_LOG_LEVEL_DEBUG, (GLogFunc) debug_handler, xplayer->settings);


### PR DESCRIPTION
…). The default behavior is to obey current system theme unless this new option is enabled. Fixes #38