### PR TITLE
Added option to display or hide subtitles

### DIFF
--- a/data/org.x.player.gschema.xml.in.in
+++ b/data/org.x.player.gschema.xml.in.in
@@ -102,6 +102,10 @@
 			<default>false</default>
 			<_summary>Whether to autoload text subtitle files when a movie is loaded</_summary>
 		</key>
+        <key name="autodisplay-subtitles" type="b">
+			<default>false</default>
+			<summary>Whether to auto-display subtitles when a movie is loaded</summary>
+		</key>
 		<key name="autoload-chapters" type="b">
 			<default>true</default>
 			<_summary>Whether to autoload external chapter files when a movie is loaded</_summary>

--- a/data/preferences.ui
+++ b/data/preferences.ui
@@ -293,7 +293,7 @@
 		      <child>
 			<object class="GtkTable" id="table3">
 			  <property name="visible">True</property>
-			  <property name="n_rows">3</property>
+			  <property name="n_rows">4</property>
 			  <property name="n_columns">2</property>
 			  <property name="homogeneous">False</property>
 			  <property name="row_spacing">6</property>
@@ -321,6 +321,28 @@
 		            </packing>
 		          </child>
 
+              <child>
+			    <object class="GtkCheckButton" id="tpw_auto_display_subtitles_checkbutton">
+			      <property name="visible">True</property>
+			      <property name="can_focus">True</property>
+			      <property name="label" translatable="yes">_Display subtitles when movie is loaded</property>
+			      <property name="use_underline">True</property>
+			      <property name="relief">GTK_RELIEF_NORMAL</property>
+			      <property name="focus_on_click">True</property>
+			      <property name="active">False</property>
+			      <property name="inconsistent">False</property>
+			      <property name="draw_indicator">True</property>
+		            </object>
+			    <packing>
+			      <property name="left_attach">0</property>
+			      <property name="right_attach">2</property>
+			      <property name="top_attach">1</property>
+			      <property name="bottom_attach">2</property>
+			      <property name="x_options">fill</property>
+			      <property name="y_options"/>
+		            </packing>
+		          </child>
+
 			  <child>
 			    <object class="GtkLabel" id="label32">
 			      <property name="visible">True</property>
@@ -343,8 +365,8 @@
 			    <packing>
 			      <property name="left_attach">0</property>
 			      <property name="right_attach">1</property>
-			      <property name="top_attach">1</property>
-			      <property name="bottom_attach">2</property>
+			      <property name="top_attach">2</property>
+			      <property name="bottom_attach">3</property>
 			      <property name="x_options">fill</property>
 			      <property name="y_options"/>
 			    </packing>
@@ -372,8 +394,8 @@
 			    <packing>
 			      <property name="left_attach">0</property>
 			      <property name="right_attach">1</property>
-			      <property name="top_attach">2</property>
-			      <property name="bottom_attach">3</property>
+			      <property name="top_attach">3</property>
+			      <property name="bottom_attach">4</property>
 			      <property name="x_options">fill</property>
 			      <property name="y_options"/>
 			    </packing>
@@ -389,8 +411,8 @@
 			    <packing>
 			      <property name="left_attach">1</property>
 			      <property name="right_attach">2</property>
-			      <property name="top_attach">2</property>
-			      <property name="bottom_attach">3</property>
+			      <property name="top_attach">3</property>
+			      <property name="bottom_attach">4</property>
 			      <property name="x_options">fill</property>
 			      <property name="y_options">fill</property>
 			    </packing>
@@ -410,8 +432,8 @@
 			    <packing>
 			      <property name="left_attach">1</property>
 			      <property name="right_attach">2</property>
-			      <property name="top_attach">1</property>
-			      <property name="bottom_attach">2</property>
+			      <property name="top_attach">2</property>
+			      <property name="bottom_attach">3</property>
 			      <property name="y_options"/>
 			    </packing>
 			  </child>

--- a/src/xplayer-object.c
+++ b/src/xplayer-object.c
@@ -1815,6 +1815,11 @@ xplayer_action_set_mrl_with_warning (XplayerObject *xplayer,
 				     GDK_BUTTON1_MASK | GDK_BUTTON3_MASK,
 				     source_table, G_N_ELEMENTS (source_table),
 				     GDK_ACTION_COPY);
+
+		/* Hide subtitles if user did not select the respective option in preferences */
+		if (g_settings_get_boolean(xplayer->settings, "autodisplay-subtitles") == FALSE)
+			/* Must be called with -2 (no subtitles) to remove the GST_PLAY_FLAG_TEXT from the flags, which is responsible for the subtitle display */
+			bacon_video_widget_set_subtitle(xplayer->bvw, -2);
 	}
 	update_buttons (xplayer);
 	update_media_menu_items (xplayer);

--- a/src/xplayer-preferences.c
+++ b/src/xplayer-preferences.c
@@ -356,6 +356,10 @@ xplayer_setup_preferences (Xplayer *xplayer)
 	item = POBJ ("tpw_auto_subtitles_checkbutton");
 	g_settings_bind (xplayer->settings, "autoload-subtitles", item, "active", G_SETTINGS_BIND_DEFAULT);
 
+	/* Auto-load subtitles */
+	item = POBJ ("tpw_auto_display_subtitles_checkbutton");
+	g_settings_bind (xplayer->settings, "autodisplay-subtitles", item, "active", G_SETTINGS_BIND_DEFAULT);
+
 	/* Auto-load external chapters */
 	item = POBJ ("tpw_auto_chapters_checkbutton");
 	g_settings_bind (xplayer->settings, "autoload-chapters", item, "active", G_SETTINGS_BIND_DEFAULT);


### PR DESCRIPTION
This will add an option to hide or show subtitles like requested in issue #57 . The default value is false, i.e. no subtitles will be displayed.