### PR TITLE
[xplayer-screenshot-plugin] Fix -Werror=format-nonliteral

### DIFF
--- a/src/plugins/screenshot/Makefile.am
+++ b/src/plugins/screenshot/Makefile.am
@@ -19,7 +19,7 @@ libscreenshot_la_SOURCES = \
 	xplayer-gallery-progress.c	\
 	xplayer-gallery-progress.h
 libscreenshot_la_LDFLAGS = $(plugin_ldflags)
-libscreenshot_la_CFLAGS = $(plugin_cflags)
+libscreenshot_la_CFLAGS = $(plugin_cflags) -Wno-format-nonliteral
 libscreenshot_la_LIBADD = $(plugin_libadd)
 
 -include $(top_srcdir)/git.mk

--- a/src/plugins/screenshot/xplayer-screenshot-plugin.c
+++ b/src/plugins/screenshot/xplayer-screenshot-plugin.c
@@ -412,6 +412,9 @@ impl_deactivate (PeasActivatable *plugin)
 }
 
 static char *
+make_filename_for_dir (const char *directory, const char *format, const char *movie_title) G_GNUC_FORMAT (2);
+
+static char *
 make_filename_for_dir (const char *directory, const char *format, const char *movie_title)
 {
 	char *fullpath, *filename;

--- a/src/plugins/screenshot/xplayer-screenshot-plugin.h
+++ b/src/plugins/screenshot/xplayer-screenshot-plugin.h
@@ -36,7 +36,7 @@
 
 G_BEGIN_DECLS
 
-gchar *xplayer_screenshot_plugin_setup_file_chooser (const char *filename_format, const char *movie_name) G_GNUC_WARN_UNUSED_RESULT;
+gchar *xplayer_screenshot_plugin_setup_file_chooser (const char *filename_format, const char *movie_name) G_GNUC_WARN_UNUSED_RESULT G_GNUC_FORMAT (1);
 void xplayer_screenshot_plugin_update_file_chooser (const char *filename);
 
 G_END_DECLS


### PR DESCRIPTION
Fixing:

```
xplayer-screenshot-plugin.c: In function 'make_filename_for_dir':
xplayer-screenshot-plugin.c:420:2: error: format not a string literal, argument types not checked [-Werror=format-nonliteral]
  filename = g_strdup_printf (_(format), movie_title, i);
  ^~~~~~~~
xplayer-screenshot-plugin.c:428:3: error: format not a string literal, argument types not checked [-Werror=format-nonliteral]
   filename = g_strdup_printf (_(format), movie_title, i);
   ^~~~~~~~
cc1: some warnings being treated as errors
make[4]: *** [Makefile:622: libscreenshot_la-xplayer-screenshot-plugin.lo] Error 1
```

Fix borrowed from [Totem](https://github.com/GNOME/totem/commit/c65abe62b4fad9f9eddf2b606eb62a7819c6e091).