### PR TITLE
Port to python3

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -135,7 +135,7 @@ Depends: ${misc:Depends},
          gir1.2-xplayer-1.0 (= ${binary:Version}),
          python-gi (>= 2.90.3),
          python-xdg,
-         libpeas-1.0-0-python2loader | libpeas-common( << 1.16 )
+         libpeas-1.0-0-python3loader | libpeas-common( << 1.16 )
 Suggests: gromit
 Description: Plugins for the Xplayer media player
  Xplayer is a simple yet featureful media player which can read

--- a/debian/control
+++ b/debian/control
@@ -133,9 +133,9 @@ Depends: ${misc:Depends},
          gir1.2-pango-1.0,
          gir1.2-peas-1.0,
          gir1.2-xplayer-1.0 (= ${binary:Version}),
-         python-gi (>= 2.90.3),
-         python-xdg,
-         libpeas-1.0-0-python3loader | libpeas-common( << 1.16 )
+         python3,
+         python3-gi,
+         libpeas-1.0-0-python3loader | debian-system-adjustments,
 Suggests: gromit
 Description: Plugins for the Xplayer media player
  Xplayer is a simple yet featureful media player which can read

--- a/src/plugins/dbusservice/dbusservice.plugin.in
+++ b/src/plugins/dbusservice/dbusservice.plugin.in
@@ -1,5 +1,5 @@
 [Plugin]
-Loader=python
+Loader=python3
 Module=dbusservice
 IAge=1
 _Name=D-Bus Service

--- a/src/plugins/dbusservice/dbusservice.py
+++ b/src/plugins/dbusservice/dbusservice.py
@@ -33,7 +33,7 @@ _ = gettext.gettext
 class DbusService (GObject.Object, Peas.Activatable):
     __gtype_name__ = 'DbusService'
 
-    object = GObject.property (type = GObject.Object)
+    object = GObject.Property (type = GObject.Object)
 
     def __init__ (self):
         GObject.Object.__init__ (self)

--- a/src/plugins/dbusservice/dbusservice.py
+++ b/src/plugins/dbusservice/dbusservice.py
@@ -94,7 +94,7 @@ class Root (dbus.service.Object): # pylint: disable-msg=R0923,R0904
             'mpris:trackid': dbus.String (self.xplayer.props.current_mrl,
                 variant_level = 1),
             'mpris:length': dbus.Int64 (
-                self.xplayer.props.stream_length * 1000L,
+                self.xplayer.props.stream_length * 1000,
                 variant_level = 1),
         }
 
@@ -152,7 +152,7 @@ class Root (dbus.service.Object): # pylint: disable-msg=R0923,R0904
     def __do_notify_current_time (self, xplayer, prop):
         # Only notify of seeks if we've skipped more than 3 seconds
         if abs (xplayer.props.current_time - self.current_position) > 3:
-            self.Seeked (xplayer.props.current_time * 1000L)
+            self.Seeked (xplayer.props.current_time * 1000)
 
         self.current_position = xplayer.props.current_time
 
@@ -198,7 +198,7 @@ class Root (dbus.service.Object): # pylint: disable-msg=R0923,R0904
                 'Shuffle': shuffle, # TODO: Notifications
                 'Metadata': self.__calculate_metadata (),
                 'Volume': self.xplayer.get_volume (), # TODO: Notifications
-                'Position': self.xplayer.props.current_time * 1000L,
+                'Position': self.xplayer.props.current_time * 1000,
                 'CanGoNext': True, # TODO
                 'CanGoPrevious': True, # TODO
                 'CanPlay': (self.xplayer.props.current_mrl != None),
@@ -315,13 +315,13 @@ class Root (dbus.service.Object): # pylint: disable-msg=R0923,R0904
                           in_signature = 'x', # pylint: disable-msg=C0103
                           out_signature = '')
     def Seek (self, offset):
-        self.xplayer.action_seek_relative (offset / 1000L, False)
+        self.xplayer.action_seek_relative (offset / 1000, False)
 
     @dbus.service.method (dbus_interface = 'org.mpris.MediaPlayer2.Player',
                           in_signature = 'ox', # pylint: disable-msg=C0103
                           out_signature = '')
     def SetPosition (self, track_id, position):
-        position = position / 1000L
+        position = position / 1000
 
         # Bail if the position is not in the permitted range
         if position < 0 or position > self.xplayer.props.stream_length:

--- a/src/plugins/dbusservice/dbusservice.py
+++ b/src/plugins/dbusservice/dbusservice.py
@@ -57,9 +57,9 @@ class Root (dbus.service.Object): # pylint: disable-msg=R0923,R0904
         self.xplayer = xplayer
 
         self.null_metadata = {
-            'year' : u'', 'tracknumber' : '', 'location' : '',
-            'title' : u'', 'album' : u'', 'time' : u'', 'genre' : u'',
-            'artist' : u''
+            'year' : '', 'tracknumber' : '', 'location' : '',
+            'title' : '', 'album' : '', 'time' : '', 'genre' : '',
+            'artist' : ''
         }
         self.current_metadata = self.null_metadata.copy ()
         self.current_position = 0
@@ -120,11 +120,11 @@ class Root (dbus.service.Object): # pylint: disable-msg=R0923,R0904
                               title, album, num):
         self.current_metadata = self.null_metadata.copy ()
         if title:
-            self.current_metadata['title'] = unicode (title, 'utf-8')
+            self.current_metadata['title'] = title
         if artist:
-            self.current_metadata['artist'] = unicode (artist, 'utf-8')
+            self.current_metadata['artist'] = artist
         if album:
-            self.current_metadata['album'] = unicode (album, 'utf-8')
+            self.current_metadata['album'] = album
         if num:
             self.current_metadata['tracknumber'] = num
 
@@ -210,7 +210,7 @@ class Root (dbus.service.Object): # pylint: disable-msg=R0923,R0904
 
         raise dbus.exceptions.DBusException (
             'org.mpris.MediaPlayer2.UnknownInterface',
-            _(u'The MediaPlayer2 object does not implement the ‘%s’ interface')
+            _('The MediaPlayer2 object does not implement the ‘%s’ interface')
                 % interface_name)
 
     @dbus.service.method (dbus_interface = dbus.PROPERTIES_IFACE,
@@ -219,7 +219,7 @@ class Root (dbus.service.Object): # pylint: disable-msg=R0923,R0904
         if interface_name == 'org.mpris.MediaPlayer2':
             raise dbus.exceptions.DBusException (
                 'org.mpris.MediaPlayer2.ReadOnlyProperty',
-                _(u'The property ‘%s’ is not writeable.'))
+                _('The property ‘%s’ is not writeable.'))
         elif interface_name == 'org.mpris.MediaPlayer2.Player':
             if property_name == 'LoopStatus':
                 self.xplayer.action_remote_set_setting (
@@ -235,12 +235,12 @@ class Root (dbus.service.Object): # pylint: disable-msg=R0923,R0904
 
             raise dbus.exceptions.DBusException (
                 'org.mpris.MediaPlayer2.ReadOnlyProperty',
-                _(u'Unknown property ‘%s’ requested of a MediaPlayer 2 object')
+                _('Unknown property ‘%s’ requested of a MediaPlayer 2 object')
                     % interface_name)
 
         raise dbus.exceptions.DBusException (
             'org.mpris.MediaPlayer2.UnknownInterface',
-            _(u'The MediaPlayer2 object does not implement the ‘%s’ interface')
+            _('The MediaPlayer2 object does not implement the ‘%s’ interface')
                 % interface_name)
 
     @dbus.service.signal (dbus_interface = dbus.PROPERTIES_IFACE,

--- a/src/plugins/opensubtitles/hash.py
+++ b/src/plugins/opensubtitles/hash.py
@@ -21,9 +21,9 @@ def hash_file (name):
     if filesize < 65536 * 2:
         return SIZE_ERROR, 0
 
-    file_handle = file (file_to_hash.get_path (), "rb")
+    file_handle = open (file_to_hash.get_path (), "rb")
 
-    for _ in range (65536 / bytesize):
+    for _ in range(int(65536 / bytesize)):
         buf = file_handle.read (bytesize)
         (l_value,) = struct.unpack (longlongformat, buf)
         file_hash += l_value
@@ -34,7 +34,7 @@ def hash_file (name):
     if file_handle.tell() != max (0, filesize - 65536):
         return SEEK_ERROR, 0
 
-    for _ in range (65536/bytesize):
+    for _ in range(int(65536/bytesize)):
         buf = file_handle.read (bytesize)
         (l_value,) = struct.unpack (longlongformat, buf)
         file_hash += l_value

--- a/src/plugins/opensubtitles/opensubtitles.plugin.in
+++ b/src/plugins/opensubtitles/opensubtitles.plugin.in
@@ -1,5 +1,5 @@
 [Plugin]
-Loader=python
+Loader=python3
 Module=opensubtitles
 IAge=1
 _Name=Subtitle Downloader

--- a/src/plugins/opensubtitles/opensubtitles.py
+++ b/src/plugins/opensubtitles/opensubtitles.py
@@ -342,6 +342,7 @@ class OpenSubtitlesModel (object):
         (log_in_success, log_in_message) = self._log_in ()
 
         if log_in_success:
+            result = None
             try:
                 result = self._server.DownloadSubtitles (self._token,
                                                          [subtitle_id])

--- a/src/plugins/opensubtitles/opensubtitles.py
+++ b/src/plugins/opensubtitles/opensubtitles.py
@@ -373,7 +373,7 @@ class OpenSubtitles (GObject.Object, # pylint: disable-msg=R0902
                      Peas.Activatable):
     __gtype_name__ = 'OpenSubtitles'
 
-    object = GObject.property (type = GObject.Object)
+    object = GObject.Property (type = GObject.Object)
 
     def __init__ (self):
         GObject.Object.__init__ (self)

--- a/src/plugins/opensubtitles/opensubtitles.py
+++ b/src/plugins/opensubtitles/opensubtitles.py
@@ -5,6 +5,7 @@ from gi.repository import Gio, Pango, Xplayer # pylint: disable-msg=E0611
 
 import xmlrpc.client
 import threading
+import zlib
 from os import sep, path, mkdir
 import gettext
 
@@ -356,14 +357,11 @@ class OpenSubtitlesModel (object):
                     self._lock.release ()
                     return (None, error_message)
 
-                import StringIO, gzip, base64
-                subtitle_decoded = base64.decodestring (subtitle64)
-                subtitle_gzipped = StringIO.StringIO (subtitle_decoded)
-                subtitle_gzipped_file = gzip.GzipFile (fileobj=subtitle_gzipped)
+                subtitle_unzipped = zlib.decompress(GLib.base64_decode (subtitle64), 47)
 
                 self._lock.release ()
 
-                return (subtitle_gzipped_file.read (), message)
+                return (subtitle_unzipped, message)
         else:
             message = log_in_message
 

--- a/src/plugins/opensubtitles/opensubtitles.py
+++ b/src/plugins/opensubtitles/opensubtitles.py
@@ -5,7 +5,6 @@ from gi.repository import Gio, Pango, Xplayer # pylint: disable-msg=E0611
 
 import xmlrpc.client
 import threading
-import xdg.BaseDirectory
 from os import sep, path, mkdir
 import gettext
 
@@ -618,19 +617,12 @@ class OpenSubtitles (GObject.Object, # pylint: disable-msg=R0902
             subtitle_format = model.get_value (subtitle_iter, 1)
 
             if not filename:
-                bpath = xdg.BaseDirectory.xdg_cache_home + sep
+                bpath = GLib.get_user_cache_dir() + sep
                 bpath += 'xplayer' + sep
 
                 directory = Gio.file_new_for_path (bpath + 'subtitles' + sep)
-
                 if not directory.query_exists (None):
-                    if not path.exists (bpath):
-                        mkdir (bpath)
-                    if not path.exists (bpath + 'subtitles' + sep):
-                        mkdir (bpath + 'subtitles' + sep)
-                    # FIXME: We can't use this function until we depend on
-                    # GLib (PyGObject) 2.18
-                    # directory.make_directory_with_parents ()
+                        directory.make_directory_with_parents (None);
 
                 subtitle_file = Gio.file_new_for_path (self._filename)
                 movie_name = subtitle_file.get_basename ().rpartition ('.')[0]

--- a/src/plugins/opensubtitles/opensubtitles.py
+++ b/src/plugins/opensubtitles/opensubtitles.py
@@ -634,7 +634,7 @@ class OpenSubtitles (GObject.Object, # pylint: disable-msg=R0902
             GObject.idle_add (self._save_subtitles, thread, filename)
 
             self._progress.set_text (_(u'Downloading the subtitles…'))
-            GObject.timeout_add (350, self._progress_bar_increment, thread)
+            GLib.timeout_add (350, self._progress_bar_increment, thread)
         else:
             #warn user!
             pass

--- a/src/plugins/pythonconsole/console.py
+++ b/src/plugins/pythonconsole/console.py
@@ -36,7 +36,7 @@ import string
 import sys
 import re
 import traceback
-from gi.repository import GObject, Pango, Gtk, Gdk # pylint: disable-msg=E0611
+from gi.repository import GLib, Pango, Gtk, Gdk # pylint: disable-msg=E0611
 
 class PythonConsole(Gtk.ScrolledWindow):
 	def __init__(self, namespace = {}, destroy_cb = None):
@@ -59,7 +59,7 @@ class PythonConsole(Gtk.ScrolledWindow):
 		self.command = buffer.create_tag("command")
 		self.command.set_property("foreground", "blue")
 
-		self.__spaces_pattern = re.compile(r'^\s+')		
+		self.__spaces_pattern = re.compile(r'^\s+')
 		self.namespace = namespace
 
 		self.block_command = False
@@ -82,8 +82,8 @@ class PythonConsole(Gtk.ScrolledWindow):
 		# Signals
 		self.view.connect("key-press-event", self.__key_press_event_cb)
 		buffer.connect("mark-set", self.__mark_set_cb)
-		
- 		
+
+
 	def __key_press_event_cb(self, view, event):
 		modifier_mask = Gtk.accelerator_get_default_mod_mask()
 		event_state = event.state & modifier_mask
@@ -114,7 +114,7 @@ class PythonConsole(Gtk.ScrolledWindow):
 				cur = buffer.get_end_iter()
 				
 			buffer.place_cursor(cur)
-			GObject.idle_add(self.scroll_to_end)
+			GLib.idle_add(self.scroll_to_end)
 			return True
 		
 		elif event.keyval == Gdk.KEY_Return:
@@ -158,21 +158,21 @@ class PythonConsole(Gtk.ScrolledWindow):
 			cur = buffer.get_end_iter()
 			buffer.move_mark(inp_mark, cur)
 			buffer.place_cursor(cur)
-			GObject.idle_add(self.scroll_to_end)
+			GLib.idle_add(self.scroll_to_end)
 			return True
 
 		elif event.keyval == Gdk.KEY_KP_Down or event.keyval == Gdk.KEY_Down:
 			# Next entry from history
 			view.emit_stop_by_name("key_press_event")
 			self.history_down()
-			GObject.idle_add(self.scroll_to_end)
+			GLib.idle_add(self.scroll_to_end)
 			return True
 
 		elif event.keyval == Gdk.KEY_KP_Up or event.keyval == Gdk.KEY_Up:
 			# Previous entry from history
 			view.emit_stop_by_name("key_press_event")
 			self.history_up()
-			GObject.idle_add(self.scroll_to_end)
+			GLib.idle_add(self.scroll_to_end)
 			return True
 
 		elif event.keyval == Gdk.KEY_KP_Left or event.keyval == Gdk.KEY_Left or \
@@ -243,22 +243,22 @@ class PythonConsole(Gtk.ScrolledWindow):
 		else:
 		    buf.insert_with_tags(buf.get_end_iter(), text, tag)
 
-		GObject.idle_add(self.scroll_to_end)
- 	
- 	def eval(self, command, display_command = False):
+		GLib.idle_add(self.scroll_to_end)
+
+	def eval(self, command, display_command = False):
 		buffer = self.view.get_buffer()
 		lin = buffer.get_mark("input-line")
 		buffer.delete(buffer.get_iter_at_mark(lin),
 		              buffer.get_end_iter())
- 
+
 		if isinstance(command, list) or isinstance(command, tuple):
- 			for c in command:
-		 		if display_command:
-		 			self.write(">>> " + c + "\n", self.command)
- 				self.__run(c)
+			for c in command:
+				if display_command:
+					self.write(">>> " + c + "\n", self.command)
+				self.__run(c)
 		else:
-	 		if display_command:
-	 			self.write(">>> " + c + "\n", self.command)
+			if display_command:
+				self.write(">>> " + c + "\n", self.command)
 			self.__run(command) 
 
 		cur = buffer.get_end_iter()
@@ -268,17 +268,17 @@ class PythonConsole(Gtk.ScrolledWindow):
 		buffer.move_mark_by_name("input", cur)
 		self.view.scroll_to_iter(buffer.get_end_iter(), 0.0, False, 0.5, 0.5)
 	
- 	def __run(self, command):
+	def __run(self, command):
 		sys.stdout, self.stdout = self.stdout, sys.stdout
 		sys.stderr, self.stderr = self.stderr, sys.stderr
-               
+
 		try:
 			try:
 				r = eval(command, self.namespace, self.namespace)
 				if r is not None:
-					print `r`
+					print(r)
 			except SyntaxError:
-				exec command in self.namespace
+				exec(command, self.namespace)
 		except:
 			if hasattr(sys, 'last_type') and sys.last_type == SystemExit:
 				self.destroy()
@@ -308,6 +308,6 @@ class OutFile:
 	def readlines(self):     return []
 	def write(self, s):      self.console.write(s, self.tag)
 	def writelines(self, l): self.console.write(l, self.tag)
-	def seek(self, a):       raise IOError, (29, 'Illegal seek')
-	def tell(self):          raise IOError, (29, 'Illegal seek')
+	def seek(self, a):       raise IOError((29, 'Illegal seek'))
+	def tell(self):          raise IOError((29, 'Illegal seek'))
 	truncate = tell

--- a/src/plugins/pythonconsole/pythonconsole.plugin.in
+++ b/src/plugins/pythonconsole/pythonconsole.plugin.in
@@ -1,5 +1,5 @@
 [Plugin]
-Loader=python
+Loader=python3
 Module=pythonconsole
 IAge=1
 _Name=Python Console

--- a/src/plugins/pythonconsole/pythonconsole.py
+++ b/src/plugins/pythonconsole/pythonconsole.py
@@ -82,36 +82,34 @@ class PythonConsolePlugin (GObject.Object, Peas.Activatable):
         data = dict ()
         manager = self.xplayer.get_ui_manager ()
 
-        data['action_group'] = Gtk.ActionGroup (name = 'Python')
+        self.action_group = Gtk.ActionGroup (name = 'Python')
 
         action = Gtk.Action (name = 'Python', label = 'Python',
-                             tooltip = _(u'Python Console Menu'),
+                             tooltip = _('Python Console Menu'),
                              stock_id = None)
-        data['action_group'].add_action (action)
+        self.action_group.add_action (action)
 
         action = Gtk.Action (name = 'PythonConsole',
-                             label = _(u'_Python Console'),
-                             tooltip = _(u"Show Xplayer's Python console"),
+                             label = _('_Python Console'),
+                             tooltip = _("Show Xplayer's Python console"),
                              stock_id = 'gnome-mime-text-x-python')
         action.connect ('activate', self._show_console)
-        data['action_group'].add_action (action)
+        self.action_group.add_action (action)
 
         action = Gtk.Action (name = 'PythonDebugger',
-                             label = _(u'Python Debugger'),
-                             tooltip = _(u"Enable remote Python debugging "\
+                             label = _('Python Debugger'),
+                             tooltip = _("Enable remote Python debugging "\
                                           "with rpdb2"),
                              stock_id = None)
         if HAVE_RPDB2:
             action.connect ('activate', self._enable_debugging)
         else:
             action.set_visible (False)
-        data['action_group'].add_action (action)
+        self.action_group.add_action (action)
 
-        manager.insert_action_group (data['action_group'], 0)
-        data['ui_id'] = manager.add_ui_from_string (UI_STR)
+        manager.insert_action_group (self.action_group, 0)
+        self.ui_id = manager.add_ui_from_string (UI_STR)
         manager.ensure_update ()
-
-        self.xplayer.PythonConsolePluginInfo = data
 
     def _show_console (self, _action):
         if not self.window:
@@ -122,11 +120,11 @@ class PythonConsolePlugin (GObject.Object, Peas.Activatable):
             }, destroy_cb = self._destroy_console)
 
             console.set_size_request (600, 400) # pylint: disable-msg=E1101
-            console.eval ('print "%s" %% xplayer_object' % _(u"You can access "\
+            console.eval ('print("%s" %% xplayer_object)' % _("You can access "\
                 "the Xplayer.Object through \'xplayer_object\' :\\n%s"), False)
 
             self.window = Gtk.Window ()
-            self.window.set_title (_(u'Xplayer Python Console'))
+            self.window.set_title (_('Xplayer Python Console'))
             self.window.add (console)
             self.window.connect ('destroy', self._destroy_console)
             self.window.show_all ()
@@ -136,7 +134,7 @@ class PythonConsolePlugin (GObject.Object, Peas.Activatable):
 
     @classmethod
     def _enable_debugging (cls, _action):
-        msg = _(u"After you press OK, Xplayer will wait until you connect to it "\
+        msg = _("After you press OK, Xplayer will wait until you connect to it "\
                  "with winpdb or rpdb2. If you have not set a debugger "\
                  "password in DConf, it will use the default password "\
                  "('xplayer').")
@@ -158,14 +156,10 @@ class PythonConsolePlugin (GObject.Object, Peas.Activatable):
         self.window = None
 
     def do_deactivate (self):
-        data = self.xplayer.PythonConsolePluginInfo
-
         manager = self.xplayer.get_ui_manager ()
-        manager.remove_ui (data['ui_id'])
-        manager.remove_action_group (data['action_group'])
+        manager.remove_ui (self.ui_id)
+        manager.remove_action_group (self.action_group)
         manager.ensure_update ()
-
-        self.xplayer.PythonConsolePluginInfo = None
 
         if self.window is not None:
             self.window.destroy ()

--- a/src/plugins/xplayer-plugins-engine.c
+++ b/src/plugins/xplayer-plugins-engine.c
@@ -121,7 +121,7 @@ xplayer_plugins_engine_get_default (XplayerObject *xplayer)
 	}
 	g_strfreev (paths);
 
-	peas_engine_enable_loader (PEAS_ENGINE (engine), "python");
+	peas_engine_enable_loader (PEAS_ENGINE (engine), "python3");
 
 	g_object_add_weak_pointer (G_OBJECT (engine),
 				   (gpointer) &engine);


### PR DESCRIPTION
Fedora has removed the python2 loader from libpeas

Based on

https://github.com/GNOME/totem/commit/e42f0dc5b287e35174158cec5d36332b7a077254
https://github.com/GNOME/totem/commit/53bf51e20899857dede61f538cac71a19e1e4163
https://github.com/GNOME/totem/commit/6022536e085e65c086282c831f27000b13f3abfe
https://github.com/GNOME/totem/commit/687b0a7391765ed7f738b9792afc90b11b9f2dc6
https://github.com/GNOME/totem/commit/3d76122be59abe3db9208fbcfe0123b8b3922bc0
https://github.com/GNOME/totem/commit/d8535bf3544ae0b7dd483bafe190f51eb62a55ab
https://github.com/GNOME/totem/commit/c76e276b415c458e38966d3ec58cd750452c9b15
https://github.com/GNOME/totem/commit/9d6a14fc25515772048ef07a2dc7343241277a43
https://github.com/GNOME/totem/commit/8c8667670f4bf9d4e6714074368e14db79c41b9a
https://github.com/GNOME/totem/commit/155ffb3cfe9acd2bf0f1caa9bcc481e1623c5ea8