### PR TITLE
pythonconsole: Import all classes to expose publicly

### DIFF
--- a/src/plugins/pythonconsole/pythonconsole.py
+++ b/src/plugins/pythonconsole/pythonconsole.py
@@ -33,7 +33,7 @@
 # Monday 7th February 2005: Christian Schaller: Add exception clause.
 # See license_change file for details.
 
-from console import PythonConsole
+from console import PythonConsole, OutFile
 
 __all__ = ('PythonConsolePlugin', 'PythonConsole', 'OutFile')
 


### PR DESCRIPTION
Based on https://github.com/GNOME/totem/commit/c53f91a3b6458bddc9261077fcf49d46f16fa1a6

The PythonConsole and OutFile classes are exposed publicly by the
console (so that the user can use them dynamically from the console); so
both must be imported from their module first.

https://bugzilla.gnome.org/show_bug.cgi?id=759075