### PR TITLE
 thumbnailer: Add upstream gstreamer blacklist changes

### DIFF
--- a/src/xplayer-video-thumbnailer.c
+++ b/src/xplayer-video-thumbnailer.c
@@ -339,7 +339,8 @@ thumb_app_setup_play (ThumbApp *app)
           "vaapivc1dec",
           "vaapivp8dec",
           "vaapivp9dec",
-          "vaapih265dec"
+          "vaapih265dec",
+          "bmcdec"
         };
         guint i;
 

--- a/src/xplayer-video-thumbnailer.c
+++ b/src/xplayer-video-thumbnailer.c
@@ -331,18 +331,11 @@ thumb_app_setup_play (ThumbApp *app)
 	GstElement *play;
 	GstElement *audio_sink, *video_sink;
 	GstRegistry *registry;
-        const char *blacklisted_plugins[] = {
-          "vaapidecodebin",
-          "vaapidecode",
-          "vaapimpeg2dec",
-          "vaapih264dec",
-          "vaapivc1dec",
-          "vaapivp8dec",
-          "vaapivp9dec",
-          "vaapih265dec",
-          "bmcdec"
-        };
-        guint i;
+	const char *blacklisted_plugins[] = {
+	  "bmcdec",
+	  "vaapi"
+	};
+	guint i;
 
 	play = gst_element_factory_make ("playbin", "play");
 	audio_sink = gst_element_factory_make ("fakesink", "audio-fake-sink");
@@ -364,12 +357,11 @@ thumb_app_setup_play (ThumbApp *app)
 	registry = gst_registry_get ();
 
 	for (i = 0; i < G_N_ELEMENTS (blacklisted_plugins); i++) {
-		GstPluginFeature *feature =
-			gst_registry_find_feature (registry,
-						   blacklisted_plugins[i],
-						   GST_TYPE_ELEMENT_FACTORY);
-		if (feature)
-			gst_registry_remove_feature (registry, feature);
+		GstPlugin *plugin =
+			gst_registry_find_plugin (registry,
+						  blacklisted_plugins[i]);
+		if (plugin)
+			gst_registry_remove_plugin (registry, plugin);
 	}
 }
 

--- a/src/xplayer-video-thumbnailer.c
+++ b/src/xplayer-video-thumbnailer.c
@@ -348,8 +348,15 @@ thumb_app_setup_play (ThumbApp *app)
 
 	/* Disable the vaapi plugin as it will not work with the
 	 * fakesink we use:
-	 * See: https://bugzilla.gnome.org/show_bug.cgi?id=700186 */
+	 * See: https://bugzilla.gnome.org/show_bug.cgi?id=700186 and
+	 * https://bugzilla.gnome.org/show_bug.cgi?id=749605 */
 	registry = gst_registry_get ();
+	feature = gst_registry_find_feature (registry,
+					     "vaapidecodebin",
+					     GST_TYPE_ELEMENT_FACTORY);
+	if (feature)
+		gst_registry_remove_feature (registry, feature);
+
 	feature = gst_registry_find_feature (registry,
 					     "vaapidecode",
 					     GST_TYPE_ELEMENT_FACTORY);

--- a/src/xplayer-video-thumbnailer.c
+++ b/src/xplayer-video-thumbnailer.c
@@ -333,7 +333,8 @@ thumb_app_setup_play (ThumbApp *app)
 	GstRegistry *registry;
 	const char *blacklisted_plugins[] = {
 	  "bmcdec",
-	  "vaapi"
+	  "vaapi",
+	  "video4linux2"
 	};
 	guint i;
 

--- a/src/xplayer-video-thumbnailer.c
+++ b/src/xplayer-video-thumbnailer.c
@@ -331,7 +331,17 @@ thumb_app_setup_play (ThumbApp *app)
 	GstElement *play;
 	GstElement *audio_sink, *video_sink;
 	GstRegistry *registry;
-	GstPluginFeature *feature;
+        const char *blacklisted_plugins[] = {
+          "vaapidecodebin",
+          "vaapidecode",
+          "vaapimpeg2dec",
+          "vaapih264dec",
+          "vaapivc1dec",
+          "vaapivp8dec",
+          "vaapivp9dec",
+          "vaapih265dec"
+        };
+        guint i;
 
 	play = gst_element_factory_make ("playbin", "play");
 	audio_sink = gst_element_factory_make ("fakesink", "audio-fake-sink");
@@ -351,18 +361,15 @@ thumb_app_setup_play (ThumbApp *app)
 	 * See: https://bugzilla.gnome.org/show_bug.cgi?id=700186 and
 	 * https://bugzilla.gnome.org/show_bug.cgi?id=749605 */
 	registry = gst_registry_get ();
-	feature = gst_registry_find_feature (registry,
-					     "vaapidecodebin",
-					     GST_TYPE_ELEMENT_FACTORY);
-	if (feature)
-		gst_registry_remove_feature (registry, feature);
 
-	feature = gst_registry_find_feature (registry,
-					     "vaapidecode",
-					     GST_TYPE_ELEMENT_FACTORY);
-	if (!feature)
-		return;
-	gst_registry_remove_feature (registry, feature);
+	for (i = 0; i < G_N_ELEMENTS (blacklisted_plugins); i++) {
+		GstPluginFeature *feature =
+			gst_registry_find_feature (registry,
+						   blacklisted_plugins[i],
+						   GST_TYPE_ELEMENT_FACTORY);
+		if (feature)
+			gst_registry_remove_feature (registry, feature);
+	}
 }
 
 static void


### PR DESCRIPTION
Based on several commits, I can squash if required.

https://github.com/GNOME/totem/commit/cc43a50c9d0f73654f56a174d17be197e4be01a8
https://github.com/GNOME/totem/commit/28bcfde30b7087c39dba3902885798fbdc888444
https://github.com/GNOME/totem/commit/8d3956f5d53aa03ab1146362fed3eacdc50c531d
https://github.com/GNOME/totem/commit/5f0f049416df05b17926e45b0d54a30dc943588b
https://github.com/GNOME/totem/commit/621a387cbe88c8084796dd601e1efc95b6fd2c00