### PR TITLE
gst: Fix GstMemory memory leak

### DIFF
--- a/src/gst/xplayer-gst-pixbuf-helpers.c
+++ b/src/gst/xplayer-gst-pixbuf-helpers.c
@@ -105,6 +105,7 @@ xplayer_gst_playbin_get_frame (GstElement *play)
       GST_ROUND_UP_4 (outwidth * 3), destroy_pixbuf, sample);
 
   gst_memory_unmap (memory, &info);
+  gst_memory_unref (memory);
 
 done:
   if (!pixbuf) {


### PR DESCRIPTION
Based on https://github.com/GNOME/totem/commit/76254280dedb94c3216edd2e7d066c53f6dd90b2