### PR TITLE
dbusservice: Force Position to be int64

### DIFF
--- a/src/plugins/dbusservice/dbusservice.py
+++ b/src/plugins/dbusservice/dbusservice.py
@@ -198,7 +198,7 @@ class Root (dbus.service.Object): # pylint: disable-msg=R0923,R0904
                 'Shuffle': shuffle, # TODO: Notifications
                 'Metadata': self.__calculate_metadata (),
                 'Volume': self.xplayer.get_volume (), # TODO: Notifications
-                'Position': self.xplayer.props.current_time * 1000,
+                'Position': dbus.Int64(self.xplayer.props.current_time * 1000),
                 'CanGoNext': True, # TODO
                 'CanGoPrevious': True, # TODO
                 'CanPlay': (self.xplayer.props.current_mrl != None),


### PR DESCRIPTION
Based on https://github.com/GNOME/totem/commit/3f48c7aa83bb26da8f8421209cddfd0be342cb81

https://bugzilla.gnome.org/show_bug.cgi?id=737476

Should fix

```
(cinnamon-screensaver-main.py:1998): GLib-GIO-WARNING **: 21:53:53.913: Received property Position with type i does not match expected type x in the expected interface

(cinnamon:16371): GLib-GIO-WARNING **: 21:53:53.915: Received property Position with type i does not match expected type x in the expected interface
```