### PR TITLE
Deal with a compilation warning (#16)

### DIFF
--- a/src/eggsmclient-xsmp.c
+++ b/src/eggsmclient-xsmp.c
@@ -1192,6 +1192,7 @@ array_prop (const char *name, ...)
       pv.value = value;
       g_array_append_val (vals, pv);
     }
+  va_end (ap);
 
   prop->num_vals = vals->len;
   prop->vals = (SmPropValue *)vals->data;


### PR DESCRIPTION
Deals with the following warning from #16:
[src/eggsmclient-xsmp.c:1201]: (error) va_list 'ap' was opened but not closed by va_end().