### PR TITLE
fix segfault in bacon-video-widget.c update_orientation_from_video

### DIFF
--- a/src/backend/bacon-video-widget.c
+++ b/src/backend/bacon-video-widget.c
@@ -1715,6 +1715,9 @@ update_orientation_from_video (BaconVideoWidget *bvw)
   if (bvw->priv->rotation != BVW_ROTATION_R_ZERO)
     return;
 
+  if (bvw->priv->tagcache == NULL)
+    return;
+
   ret = gst_tag_list_get_string_index (bvw->priv->tagcache,
 				       GST_TAG_IMAGE_ORIENTATION, 0, &orientation_str);
   if (!ret || !orientation_str || g_str_equal (orientation_str, "rotate-0"))


### PR DESCRIPTION
The segfault occurs when bvw->priv->tagcache is NULL and is passed in to gst_tag_list_get_string_index()

As far as I can tell, in all other cases where bvw->priv->tagcache is used, it is either checked for NULL already, or it is passed in to a function that can accept NULLs (g_clear_pointer or gst_tag_list_merge)