### PR TITLE
Fix compiler errors related to invalid/missing type casts

### DIFF
--- a/src/backend/bacon-video-widget-gst-missing-plugins.c
+++ b/src/backend/bacon-video-widget-gst-missing-plugins.c
@@ -282,7 +282,7 @@ bacon_video_widget_start_plugin_installation (XplayerCodecInstallContext *ctx,
 	}
 #endif /* GDK_WINDOWING_X11 */
 
-	status = gst_install_plugins_async (ctx->details, install_ctx,
+	status = gst_install_plugins_async ((const gchar * const*)ctx->details, install_ctx,
 	                                    on_plugin_installation_done,
 	                                    ctx);
 

--- a/src/backend/bacon-video-widget.c
+++ b/src/backend/bacon-video-widget.c
@@ -1923,7 +1923,7 @@ bvw_handle_buffering_message (GstMessage * message, BaconVideoWidget *bvw)
        gst_element_set_state (GST_ELEMENT (bvw->priv->play), GST_STATE_PAUSED);
 
        bvw_reconfigure_fill_timeout (bvw, 200);
-       bvw->priv->download_buffering_element = g_object_ref (message->src);
+       bvw->priv->download_buffering_element = GST_ELEMENT_CAST(g_object_ref (message->src));
      }
 
      return;

--- a/src/backend/gsd-osd-window.c
+++ b/src/backend/gsd-osd-window.c
@@ -250,7 +250,7 @@ draw_action_custom (GsdOsdDrawContext  *ctx,
                 g_free (name);
                 if (pixbuf == NULL)
                 {
-                    return FALSE;
+                    return;
                 }
             }
 

--- a/src/xplayer-fullscreen.c
+++ b/src/xplayer-fullscreen.c
@@ -585,7 +585,7 @@ xplayer_fullscreen_toggle_blank_monitors (XplayerFullscreen *fs, GtkWidget *wind
 		xapp_monitor_blanker_unblank_monitors(fs->xapp_monitor_blanker);
 	}
 	else {
-		xapp_monitor_blanker_blank_other_monitors(fs->xapp_monitor_blanker, window);
+		xapp_monitor_blanker_blank_other_monitors(fs->xapp_monitor_blanker, GTK_WINDOW(window));
 	}
 	xplayer_fullscreen_move_popups (fs);
 }

--- a/src/xplayer-object.c
+++ b/src/xplayer-object.c
@@ -1612,7 +1612,7 @@ xplayer_action_fullscreen (XplayerObject *xplayer, gboolean state)
 void
 xplayer_action_blank (XplayerObject *xplayer)
 {
-	xplayer_fullscreen_toggle_blank_monitors(xplayer->fs, GTK_WINDOW (xplayer->win));
+	xplayer_fullscreen_toggle_blank_monitors(xplayer->fs, GTK_WIDGET (xplayer->win));
 }
 
 void
@@ -4304,7 +4304,7 @@ xplayer_callback_connect (XplayerObject *xplayer)
 	gtk_action_set_sensitive (action, FALSE);
 
     sidebar_toolbar = xplayer_playlist_get_toolbar (xplayer->playlist);
-    size_box = GTK_BOX (gtk_builder_get_object (xplayer->xml, "tmw_controls_vbox"));
+    size_box = GTK_WIDGET (gtk_builder_get_object (xplayer->xml, "tmw_controls_vbox"));
     size_group = gtk_size_group_new (GTK_SIZE_GROUP_VERTICAL);
     gtk_size_group_add_widget (size_group, size_box);
     gtk_size_group_add_widget (size_group, sidebar_toolbar);

--- a/src/xplayer-private.h
+++ b/src/xplayer-private.h
@@ -106,7 +106,7 @@ struct _XplayerObject {
 	GtkAdjustment *seekadj;
 	gboolean seek_lock;
 	gboolean seekable;
-	XplayerTimeLabel *time_label;
+	GtkWidget *time_label;
 
 	/* Volume */
 	GtkWidget *volume;


### PR DESCRIPTION
Something updated here on archlinux which turned invalid type cast warnings into errors. Maybe a gcc or toolchain update... honestly not sure because after looking for about 10 minutes I decided it'd be easier to just fix it here rather than root cause the change which caused it.

This commit resolves a handful of these compiler warnings which are now cause build failures on arch. As far as I can tell, there's no functional change here since I didn't note any bad logic in the code pointed out by the warnings. I just adjusted the types and casting to more accurately reflect the intended behavior.